### PR TITLE
if user is subscribed then subscribed button should be shown in grey colour other wise it should be red #51

### DIFF
--- a/client/src/pages/Video.jsx
+++ b/client/src/pages/Video.jsx
@@ -101,7 +101,7 @@ const Description = styled.p`
 `;
 
 const Subscribe = styled.button`
-  background-color: #cc1a00;
+  background-color:  ${props => (props.isSubscribed ? '#a1a6ad' : '#cc1a00')};
   font-weight: 500;
   color: white;
   border: none;
@@ -236,7 +236,7 @@ const Video = () => {
                 <Description>{currentVideo.desc}</Description>
               </ChannelDetail>
             </ChannelInfo>
-            <Subscribe onClick={handleSub}>
+            <Subscribe onClick={handleSub} isSubscribed={currentUser?.subscribedUsers?.includes(channel._id)?true:false}>
               {currentUser?.subscribedUsers?.includes(channel._id)
                 ? "SUBSCRIBED"
                 : "SUBSCRIBE"}


### PR DESCRIPTION
## Fixes Issue

This PR fixes the following issues: [Feature]: if user is subscribed then subscribed button should be shown in grey colour other wise it should be red #51

#example

in Subscribed  styled component added ternary props.isSubscribed for background-color
added prop isSubscribed line 

## Changes proposed

Here comes all the changes proposed through this PR

<!-- Check all the boxes which are applicable to check the box correct follow the following conventions-->
<!--
[x] - Correct
[X] - Correct
-->

## Check List (Check all the boxes which are applicable) <!--Follow the above conventions to check the box-->

- [x ] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] All new and existing tests passed.
- [ x] This PR does not contain plagiarized content.
- [ x] The title of my pull request is a short description of the requested changes.

<!--Add screen shots of the changed output-->

![Screen Shot 2023-02-27 at 5 52 45 PM](https://user-images.githubusercontent.com/67371345/221563292-48942f90-829b-4c4e-b7af-76c7cf5875ec.png)
![Screen Shot 2023-02-27 at 5 52 39 PM](https://user-images.githubusercontent.com/67371345/221563301-2c229db4-17cd-485f-94bf-82ab6a66ce3f.png)


Add all the screenshots and a video which support your changes 
